### PR TITLE
This updates the drivers to compile against a 6.12.34 kernel.

### DIFF
--- a/drivers/fr_imx662.c
+++ b/drivers/fr_imx662.c
@@ -7,7 +7,7 @@
 
 //#define DEBUG 1
 
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
@@ -490,9 +490,9 @@ static int imx662_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
 	struct imx662 *imx662 = to_imx662(sd);
 	struct v4l2_mbus_framefmt *try_fmt_img =
-		v4l2_subdev_get_try_format(sd, fh->state, IMAGE_PAD);
+		v4l2_subdev_state_get_format(fh->state, IMAGE_PAD);
 	struct v4l2_mbus_framefmt *try_fmt_meta =
-		v4l2_subdev_get_try_format(sd, fh->state, METADATA_PAD);
+		v4l2_subdev_state_get_format(fh->state, METADATA_PAD);
 	struct v4l2_rect *try_crop;
 
 	mutex_lock(&imx662->mutex);
@@ -508,7 +508,7 @@ static int imx662_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	try_fmt_meta->code = MEDIA_BUS_FMT_SENSOR_DATA;
 	try_fmt_meta->field = V4L2_FIELD_NONE;
 
-	try_crop = v4l2_subdev_get_try_crop(sd, fh->state, IMAGE_PAD);
+	try_crop = v4l2_subdev_state_get_crop(fh->state, IMAGE_PAD);
 	try_crop->left = IMX662_PIXEL_ARRAY_LEFT;
 	try_crop->top = IMX662_PIXEL_ARRAY_TOP;
 	try_crop->width = IMX662_PIXEL_ARRAY_WIDTH;
@@ -950,7 +950,7 @@ static int imx662_get_pad_format(struct v4l2_subdev *sd,
 
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
 		struct v4l2_mbus_framefmt *try_fmt =
-			v4l2_subdev_get_try_format(&imx662->sd, sd_state,
+			v4l2_subdev_state_get_format(sd_state,
 							fmt->pad);
 		try_fmt->code = fmt->pad == IMAGE_PAD ?
 				imx662_get_format_code(imx662, try_fmt->code) :
@@ -1050,7 +1050,7 @@ static int imx662_set_pad_format(struct v4l2_subdev *sd,
 		imx662_update_image_pad_format(imx662, mode, fmt);
 
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else if (imx662->mode != mode) {
@@ -1060,7 +1060,7 @@ static int imx662_set_pad_format(struct v4l2_subdev *sd,
 		}
 	} else {
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else {
@@ -1080,7 +1080,7 @@ __imx662_get_pad_crop(struct imx662 *imx662,
 {
 	switch (which) {
 	case V4L2_SUBDEV_FORMAT_TRY:
-		return v4l2_subdev_get_try_crop(&imx662->sd, sd_state, pad);
+		return v4l2_subdev_state_get_crop(sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
 		return &imx662->mode->crop;
 	}

--- a/drivers/fr_imx676.c
+++ b/drivers/fr_imx676.c
@@ -7,7 +7,7 @@
 
 //#define DEBUG 1
 
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
@@ -472,9 +472,9 @@ static int imx676_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
 	struct imx676 *imx676 = to_imx676(sd);
 	struct v4l2_mbus_framefmt *try_fmt_img =
-		v4l2_subdev_get_try_format(sd, fh->state, IMAGE_PAD);
+		v4l2_subdev_state_get_format(fh->state, IMAGE_PAD);
 	struct v4l2_mbus_framefmt *try_fmt_meta =
-		v4l2_subdev_get_try_format(sd, fh->state, METADATA_PAD);
+		v4l2_subdev_state_get_format(fh->state, METADATA_PAD);
 	struct v4l2_rect *try_crop;
 
 	mutex_lock(&imx676->mutex);
@@ -490,7 +490,7 @@ static int imx676_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	try_fmt_meta->code = MEDIA_BUS_FMT_SENSOR_DATA;
 	try_fmt_meta->field = V4L2_FIELD_NONE;
 
-	try_crop = v4l2_subdev_get_try_crop(sd, fh->state, IMAGE_PAD);
+	try_crop = v4l2_subdev_state_get_crop(fh->state, IMAGE_PAD);
 	try_crop->left = IMX676_PIXEL_ARRAY_LEFT;
 	try_crop->top = IMX676_PIXEL_ARRAY_TOP;
 	try_crop->width = IMX676_PIXEL_ARRAY_WIDTH;
@@ -948,7 +948,7 @@ static int imx676_get_pad_format(struct v4l2_subdev *sd,
 
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
 		struct v4l2_mbus_framefmt *try_fmt =
-			v4l2_subdev_get_try_format(&imx676->sd, sd_state,
+			v4l2_subdev_state_get_format(sd_state,
 							fmt->pad);
 		try_fmt->code = fmt->pad == IMAGE_PAD ?
 				imx676_get_format_code(imx676, try_fmt->code) :
@@ -1048,7 +1048,7 @@ static int imx676_set_pad_format(struct v4l2_subdev *sd,
 		imx676_update_image_pad_format(imx676, mode, fmt);
 
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else if (imx676->mode != mode) {
@@ -1058,7 +1058,7 @@ static int imx676_set_pad_format(struct v4l2_subdev *sd,
 		}
 	} else {
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else {
@@ -1078,7 +1078,7 @@ __imx676_get_pad_crop(struct imx676 *imx676,
 {
 	switch (which) {
 	case V4L2_SUBDEV_FORMAT_TRY:
-		return v4l2_subdev_get_try_crop(&imx676->sd, sd_state, pad);
+		return v4l2_subdev_state_get_crop(sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
 		return &imx676->mode->crop;
 	}

--- a/drivers/fr_imx678.c
+++ b/drivers/fr_imx678.c
@@ -7,7 +7,7 @@
 
 //#define DEBUG 1
 
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
@@ -492,9 +492,9 @@ static int imx678_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
 	struct imx678 *imx678 = to_imx678(sd);
 	struct v4l2_mbus_framefmt *try_fmt_img =
-		v4l2_subdev_get_try_format(sd, fh->state, IMAGE_PAD);
+		v4l2_subdev_state_get_format(fh->state, IMAGE_PAD);
 	struct v4l2_mbus_framefmt *try_fmt_meta =
-		v4l2_subdev_get_try_format(sd, fh->state, METADATA_PAD);
+		v4l2_subdev_state_get_format(fh->state, METADATA_PAD);
 	struct v4l2_rect *try_crop;
 
 	mutex_lock(&imx678->mutex);
@@ -510,7 +510,7 @@ static int imx678_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	try_fmt_meta->code = MEDIA_BUS_FMT_SENSOR_DATA;
 	try_fmt_meta->field = V4L2_FIELD_NONE;
 
-	try_crop = v4l2_subdev_get_try_crop(sd, fh->state, IMAGE_PAD);
+	try_crop = v4l2_subdev_state_get_crop(fh->state, IMAGE_PAD);
 	try_crop->left = IMX678_PIXEL_ARRAY_LEFT;
 	try_crop->top = IMX678_PIXEL_ARRAY_TOP;
 	try_crop->width = IMX678_PIXEL_ARRAY_WIDTH;
@@ -960,7 +960,7 @@ static int imx678_get_pad_format(struct v4l2_subdev *sd,
 
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
 		struct v4l2_mbus_framefmt *try_fmt =
-			v4l2_subdev_get_try_format(&imx678->sd, sd_state,
+			v4l2_subdev_state_get_format(sd_state,
 							fmt->pad);
 		try_fmt->code = fmt->pad == IMAGE_PAD ?
 				imx678_get_format_code(imx678, try_fmt->code) :
@@ -1060,7 +1060,7 @@ static int imx678_set_pad_format(struct v4l2_subdev *sd,
 		imx678_update_image_pad_format(imx678, mode, fmt);
 
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else if (imx678->mode != mode) {
@@ -1070,7 +1070,7 @@ static int imx678_set_pad_format(struct v4l2_subdev *sd,
 		}
 	} else {
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else {
@@ -1090,7 +1090,7 @@ __imx678_get_pad_crop(struct imx678 *imx678,
 {
 	switch (which) {
 	case V4L2_SUBDEV_FORMAT_TRY:
-		return v4l2_subdev_get_try_crop(&imx678->sd, sd_state, pad);
+		return v4l2_subdev_state_get_crop(sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
 		return &imx678->mode->crop;
 	}

--- a/drivers/fr_imx900.c
+++ b/drivers/fr_imx900.c
@@ -7,7 +7,7 @@
 
 //#define DEBUG 1
 
-#include <asm/unaligned.h>
+#include <linux/unaligned.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
 #include <linux/i2c.h>
@@ -703,9 +703,9 @@ static int imx900_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 {
 	struct imx900 *imx900 = to_imx900(sd);
 	struct v4l2_mbus_framefmt *try_fmt_img =
-		v4l2_subdev_get_try_format(sd, fh->state, IMAGE_PAD);
+		v4l2_subdev_state_get_format(fh->state, IMAGE_PAD);
 	struct v4l2_mbus_framefmt *try_fmt_meta =
-		v4l2_subdev_get_try_format(sd, fh->state, METADATA_PAD);
+		v4l2_subdev_state_get_format(fh->state, METADATA_PAD);
 	struct v4l2_rect *try_crop;
 
 	mutex_lock(&imx900->mutex);
@@ -726,7 +726,7 @@ static int imx900_open(struct v4l2_subdev *sd, struct v4l2_subdev_fh *fh)
 	try_fmt_meta->code = MEDIA_BUS_FMT_SENSOR_DATA;
 	try_fmt_meta->field = V4L2_FIELD_NONE;
 
-	try_crop = v4l2_subdev_get_try_crop(sd, fh->state, IMAGE_PAD);
+	try_crop = v4l2_subdev_state_get_crop(fh->state, IMAGE_PAD);
 	try_crop->left = IMX900_PIXEL_ARRAY_LEFT;
 	try_crop->top = IMX900_PIXEL_ARRAY_TOP;
 	try_crop->width = IMX900_PIXEL_ARRAY_WIDTH;
@@ -1686,7 +1686,7 @@ static int imx900_get_pad_format(struct v4l2_subdev *sd,
 
 	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
 		struct v4l2_mbus_framefmt *try_fmt =
-			v4l2_subdev_get_try_format(&imx900->sd, sd_state,
+			v4l2_subdev_state_get_format(sd_state,
 							fmt->pad);
 		try_fmt->code = fmt->pad == IMAGE_PAD ?
 				imx900_get_format_code(imx900, try_fmt->code) :
@@ -1771,7 +1771,7 @@ static int imx900_set_pad_format(struct v4l2_subdev *sd,
 		imx900_update_image_pad_format(imx900, mode, fmt);
 
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else if (imx900->mode != mode) {
@@ -1781,7 +1781,7 @@ static int imx900_set_pad_format(struct v4l2_subdev *sd,
 		}
 	} else {
 		if (fmt->which == V4L2_SUBDEV_FORMAT_TRY) {
-			framefmt = v4l2_subdev_get_try_format(sd, sd_state,
+			framefmt = v4l2_subdev_state_get_format(sd_state,
 								fmt->pad);
 			*framefmt = fmt->format;
 		} else {
@@ -1801,7 +1801,7 @@ __imx900_get_pad_crop(struct imx900 *imx900,
 {
 	switch (which) {
 	case V4L2_SUBDEV_FORMAT_TRY:
-		return v4l2_subdev_get_try_crop(&imx900->sd, sd_state, pad);
+		return v4l2_subdev_state_get_crop(sd_state, pad);
 	case V4L2_SUBDEV_FORMAT_ACTIVE:
 		return &imx900->mode->crop;
 	}


### PR DESCRIPTION
This updates the drivers to compile against a 6.12.34 kernel.

Tested on:

```
System Information
------------------

Raspberry Pi Compute Module 5 Rev 1.0
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"

Generated using rpi-image-gen d1cc39bc57f14e7ba3ca0ae5fe38dbae5b57ba17 on 2025-08-14

Linux cm5 6.12.34+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.12.34-1+rpt1 (2025-06-26) aarch64 GNU/Linux
Revision    : d04180
Serial      : **************
Model       : Raspberry Pi Compute Module 5 Rev 1.0
```

`uname -a`:
```
cm5@cm5:~/framos-rpi-drivers$ uname -a
Linux cm5 6.12.34+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.12.34-1+rpt1 (2025-06-26) aarch64 GNU/Linux
cm5@cm5:~/framos-rpi-drivers$
```